### PR TITLE
dump: Flush dump data buffer

### DIFF
--- a/src/p2G4_args.c
+++ b/src/p2G4_args.c
@@ -79,6 +79,7 @@ void p2G4_argsparse(int argc, char *argv[], p2G4_args_t *args)
       ARG_TABLE_NOCOLOR,
       ARG_TABLE_FORCECOLOR,
       { false, false  , true,  "nodump",    "no_dump",  'b', (void*)&args->dont_dump,      NULL,         "Will not dump (or compare) any files"},
+      { false, false  , true,  "dump_imm",  "dump_imm", 'b', (void*)&args->dump_imm,       NULL,         "When dumping, do not buffer more than a line"},
       { false, false  , true,  "dump",      "dump",     'b', (void*)NULL,                 dump_found,    "Revert -nodump option (note that the last -nodump/dump set in the command line prevails)"},
       { false, false  , true,  "c",          "compare", 'b', (void*)&args->compare,        NULL,         "Run in compare mode: will compare instead of dumping"},
       { false, false  , true,  "stop_on_diff","stop",   'b', (void*)&args->stop_on_diff,  stop_found,    "Run in compare mode, but stop as soon as a difference is found"},

--- a/src/p2G4_args.h
+++ b/src/p2G4_args.h
@@ -19,6 +19,7 @@ typedef struct{
   ARG_P_ID
   bs_time_t sim_length;
   bool dont_dump;
+  bool dump_imm;
   bool compare;
   bool stop_on_diff;
   ARG_VERB

--- a/src/p2G4_dump.c
+++ b/src/p2G4_dump.c
@@ -114,7 +114,7 @@ static FILE* open_file(size_t fname_len, const char* results_path, const char* t
 /**
  * Prepare dumping
  */
-void open_dump_files(uint8_t comp_i, uint8_t stop, const char* s,
+void open_dump_files(uint8_t comp_i, uint8_t stop, uint8_t dump_imm, const char* s,
                      const char* p, const uint n_dev_i){
   char* path;
 
@@ -138,6 +138,12 @@ void open_dump_files(uint8_t comp_i, uint8_t stop, const char* s,
     modemrx_f[i] = open_file(fname_len, path, "ModemRx", p, i);
 
     if (comp == 0) {
+      if (dump_imm) {
+        setvbuf(tx_f[i], NULL, _IOLBF, 0);
+        setvbuf(rx_f[i], NULL, _IOLBF, 0);
+        setvbuf(RSSI_f[i], NULL, _IOLBF, 0);
+        setvbuf(modemrx_f[i], NULL, _IOLBF, 0);
+      }
       dump_tx_heading(tx_f[i]);
       dump_rx_heading(rx_f[i]);
       dump_RSSI_heading(RSSI_f[i]);

--- a/src/p2G4_dump.h
+++ b/src/p2G4_dump.h
@@ -29,7 +29,7 @@ extern "C"{
 /**
  * Open all dump files (as configured from command line)
  */
-void open_dump_files(uint8_t comp_i, uint8_t stop, const char* s,
+void open_dump_files(uint8_t comp_i, uint8_t stop, uint8_t dump_imm, const char* s,
                      const char* p, const uint n_dev_i);
 
 /**

--- a/src/p2G4_main.c
+++ b/src/p2G4_main.c
@@ -595,7 +595,7 @@ int main(int argc, char *argv[]) {
   RSSI_a = bs_malloc(sizeof(p2G4_rssi_t)*args.n_devs);
   rx_a = bs_malloc(sizeof(rx_status_t)*args.n_devs);
 
-  if (args.dont_dump == 0) open_dump_files(args.compare, args.stop_on_diff, args.s_id, args.p_id, args.n_devs);
+  if (args.dont_dump == 0) open_dump_files(args.compare, args.stop_on_diff, args.dump_imm, args.s_id, args.p_id, args.n_devs);
 
   nbr_active_devs = args.n_devs;
 


### PR DESCRIPTION
To avoid stream buffering, flush to write all of the
data to the dump file immediately. As the dumps are
used for testing purposes it is crucial to avoid
waiting for buffer to fill up while debugging the
application.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>