### PR TITLE
Add option to deliver packet data even for packets with CRC errors

### DIFF
--- a/src/p2G4_args.c
+++ b/src/p2G4_args.c
@@ -81,6 +81,7 @@ void p2G4_argsparse(int argc, char *argv[], p2G4_args_t *args)
       { false, false  , true,  "nodump",    "no_dump",  'b', (void*)&args->dont_dump,      NULL,         "Will not dump (or compare) any files"},
       { false, false  , true,  "dump_imm",  "dump_imm", 'b', (void*)&args->dump_imm,       NULL,         "When dumping, do not buffer more than a line"},
       { false, false  , true,  "dump",      "dump",     'b', (void*)NULL,                 dump_found,    "Revert -nodump option (note that the last -nodump/dump set in the command line prevails)"},
+      { false, false  , true,  "crcerr_data","crcerr",  'b', (void*)&args->crcerr_data,    NULL,         "Provide uncorrupted packet to device attempting to receive even if packet has a CRC error or reception is aborted midway (disabled by default)"},
       { false, false  , true,  "c",          "compare", 'b', (void*)&args->compare,        NULL,         "Run in compare mode: will compare instead of dumping"},
       { false, false  , true,  "stop_on_diff","stop",   'b', (void*)&args->stop_on_diff,  stop_found,    "Run in compare mode, but stop as soon as a difference is found"},
       { false, false  , false, "channel",    "channel", 's', (void*)&args->channel_name,  channel_found, "Which channel will be used ( lib/lib_2G4Channel_<channel>.so ). By default NtNcable"},

--- a/src/p2G4_args.h
+++ b/src/p2G4_args.h
@@ -20,6 +20,7 @@ typedef struct{
   bs_time_t sim_length;
   bool dont_dump;
   bool dump_imm;
+  bool crcerr_data;
   bool compare;
   bool stop_on_diff;
   ARG_VERB

--- a/src/p2G4_main.c
+++ b/src/p2G4_main.c
@@ -366,7 +366,9 @@ static void f_rx_payload(uint d){
 
   if (((current_time >= rx_a[d].payload_end) && (rx_a[d].biterrors > 0))
       || (current_time >= rx_a[d].rx_s.abort.abort_time)) {
-    rx_a[d].rx_done_s.packet_size = 0;
+    if (!args.crcerr_data) {
+        rx_a[d].rx_done_s.packet_size = 0;
+    }
     rx_a[d].rx_done_s.status = P2G4_RXSTATUS_CRC_ERROR;
     bs_trace_raw_time(8,"RxDone (CRC error) for device %u\n", d);
     rx_a[d].rx_done_s.end_time = current_time;


### PR DESCRIPTION
This change enables to simulate the behavior of some radios more
accurately. However, the data is delivered as-is, i.e., bit errors are
not simulated.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>